### PR TITLE
improve pygo-jwt error handling

### DIFF
--- a/pygo-jwt/config.json
+++ b/pygo-jwt/config.json
@@ -16,7 +16,7 @@
     "BoolWithError* ParsePublicPEMAndVerify(char* key, char* data, char* signature);",
     "void ExampleGo(int n);",
     "StringWithError* MaybeError(int n);",
-    "void FreeCString(char* data);",
+    "void FreeString(char* data);",
     "void FreeStringWithError(StringWithError* object);",
     "void FreeBoolWithError(BoolWithError* object);"
   ]

--- a/pygo-jwt/config.json
+++ b/pygo-jwt/config.json
@@ -3,18 +3,21 @@
   "extension": "_rsa_util",
   "library": "rsautil",
   "signatures": [
-    "char* NewJWK(int size, char* id);",
-    "char* JWKToPEM(char* json_data);",
-    "char* PEMToJWK(char* pem, char* id);",
-    "char* ExtractPublicJWK(char* key);",
-    "char* ExtractPublicPEM(char* key);",
-    "char* ParseJWKAndSign(char* key, char* data);",
-    "char* ParsePEMAndSign(char* key, char* data);",
-    "_Bool ParsePublicJWKAndVerify(char* key, char* data, char* signature);",
-    "_Bool ParsePublicPEMAndVerify(char* key, char* data, char* signature);",
-    "void FreeCString(char* data);",
-    "void ExampleGo(int n);",
     "typedef struct string_with_error {char* data; char* error;} StringWithError;",
-    "StringWithError MaybeError(int n);"
+    "typedef struct bool_with_error {bool data; char* error;} BoolWithError;",
+    "StringWithError* NewJWK(int size, char* id);",
+    "StringWithError* JWKToPEM(char* json_data);",
+    "StringWithError* PEMToJWK(char* pem, char* id);",
+    "StringWithError* ExtractPublicJWK(char* key);",
+    "StringWithError* ExtractPublicPEM(char* key);",
+    "StringWithError* ParseJWKAndSign(char* key, char* data);",
+    "StringWithError* ParsePEMAndSign(char* key, char* data);",
+    "BoolWithError* ParsePublicJWKAndVerify(char* key, char* data, char* signature);",
+    "BoolWithError* ParsePublicPEMAndVerify(char* key, char* data, char* signature);",
+    "void ExampleGo(int n);",
+    "StringWithError* MaybeError(int n);",
+    "void FreeCString(char* data);",
+    "void FreeStringWithError(StringWithError* object);",
+    "void FreeBoolWithError(BoolWithError* object);"
   ]
 }

--- a/pygo-jwt/config.json
+++ b/pygo-jwt/config.json
@@ -14,6 +14,7 @@
     "_Bool ParsePublicPEMAndVerify(char* key, char* data, char* signature);",
     "void FreeCString(char* data);",
     "void ExampleGo(int n);",
+    "typedef struct string_with_error {char* data; char* error;} StringWithError;",
     "StringWithError MaybeError(int n);"
   ]
 }

--- a/pygo-jwt/config.json
+++ b/pygo-jwt/config.json
@@ -13,6 +13,7 @@
     "_Bool ParsePublicJWKAndVerify(char* key, char* data, char* signature);",
     "_Bool ParsePublicPEMAndVerify(char* key, char* data, char* signature);",
     "void FreeCString(char* data);",
-    "void ExampleGo(int n);"
+    "void ExampleGo(int n);",
+    "StringWithError MaybeError(int n);"
   ]
 }

--- a/pygo-jwt/docs/todo.md
+++ b/pygo-jwt/docs/todo.md
@@ -20,3 +20,4 @@
 ### For PYGO Tools
 - [ ] decouple patch logic to allow caller to define wheel path location?
 - [ ] update `build-ffi` to include custom header files, like `wrapper_util.h`
+- [ ] move `wrapper_util` logic to `pygo-tools`

--- a/pygo-jwt/docs/todo.md
+++ b/pygo-jwt/docs/todo.md
@@ -7,7 +7,9 @@
 - [ ] implement practical helpers:
     - [ ] encode tokens with claims `iss` `aud` `exp` `iat`, `nbf`
     - [ ] decode tokens with key server `PyJWKClient`
-- [x] improve error handling; remove `panic` in core logic
+- [ ] improve error handling
+    - [ ] remove `panic` in core logic
+    - [ ] explore `panic` and `recover`
 - [ ] research source distribution build
 - [ ] test for windows?
 

--- a/pygo-jwt/docs/todo.md
+++ b/pygo-jwt/docs/todo.md
@@ -19,3 +19,4 @@
 
 ### For PYGO Tools
 - [ ] decouple patch logic to allow caller to define wheel path location?
+- [ ] update `build-ffi` to include custom header files, like `wrapper_util.h`

--- a/pygo-jwt/docs/todo.md
+++ b/pygo-jwt/docs/todo.md
@@ -8,10 +8,12 @@
     - [ ] encode tokens with claims `iss` `aud` `exp` `iat`, `nbf`
     - [ ] decode tokens with key server `PyJWKClient`
 - [ ] improve error handling
-    - [ ] remove `panic` in core logic
+    - [x] remove `panic` in core logic
     - [ ] explore `panic` and `recover`
+    - [ ] research error propagation; try/catch
 - [ ] research source distribution build
 - [ ] test for windows?
+- [ ] check code formatting
 
 ### Blocked
 - [ ] support alpine linux; remove skip

--- a/pygo-jwt/docs/todo.md
+++ b/pygo-jwt/docs/todo.md
@@ -7,6 +7,7 @@
 - [ ] implement practical helpers:
     - [ ] encode tokens with claims `iss` `aud` `exp` `iat`, `nbf`
     - [ ] decode tokens with key server `PyJWKClient`
+- [x] improve error handling; remove `panic` in core logic
 - [ ] research source distribution build
 - [ ] test for windows?
 

--- a/pygo-jwt/pygo_jwt/errors.py
+++ b/pygo-jwt/pygo_jwt/errors.py
@@ -8,3 +8,7 @@ class TokenDecodeError(PyGoJWTError):
 
 class InvalidSignatureError(TokenDecodeError):
     pass
+
+
+class CorePyGoJWTError(PyGoJWTError):
+    pass

--- a/pygo-jwt/pygo_jwt/go/Makefile
+++ b/pygo-jwt/pygo_jwt/go/Makefile
@@ -1,7 +1,7 @@
 all: clean build
 
 build:
-	go build -buildmode=c-shared -o local/librsautil.so wrapper.go
+	go build -buildmode=c-shared -o local/librsautil.so wrapper.go wrapper_util.go
 	@# go tool cgo wrapper.go
 
 clean:

--- a/pygo-jwt/pygo_jwt/go/Makefile
+++ b/pygo-jwt/pygo_jwt/go/Makefile
@@ -1,16 +1,14 @@
-all: clean build
-
-build:
+build: clean
 	go build -buildmode=c-shared -o local/librsautil.so wrapper.go wrapper_util.go
-	@# go tool cgo wrapper.go
+	@# go tool cgo wrapper.go wrapper_util.go
 
 clean:
-	@rm -rf local
+	@rm -rf local _obj
 
-test:
+test: clean
 	@go test
 
-reset:
+reset: clean
 	@rm -f go.sum
 	@go clean -modcache # remove download modules
 	@go mod tidy # reinstall dependencies

--- a/pygo-jwt/pygo_jwt/go/core/conversions.go
+++ b/pygo-jwt/pygo_jwt/go/core/conversions.go
@@ -5,22 +5,31 @@ import (
 	"github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/util"
 )
 
-func NewJWK(size int, id *string) string {
-	key := NewKey(size)
+func NewJWK(size int, id *string) (string, error) {
+	key, err := NewKey(size)
+	if err != nil {
+		return "", err
+	}
 	return KeyToJSON(key, id)
 }
 
-func KeyToJSON(key *rsa.PrivateKey, id *string) string {
+func KeyToJSON(key *rsa.PrivateKey, id *string) (string, error) {
 	data := KeyToMap(key, id)
 	return util.MapToJSON(data)
 }
 
-func JWKToPEM(jwk string) string {
-	key := ParseJWK(jwk)
+func JWKToPEM(jwk string) (string, error) {
+	key, err := ParseJWK(jwk)
+	if err != nil {
+		return "", err
+	}
 	return KeyToPEM(key)
 }
 
-func PEMToJWK(data string, id *string) string {
-	key := ParsePEM(data)
+func PEMToJWK(data string, id *string) (string, error) {
+	key, err := ParsePEM(data)
+	if err != nil {
+		return "", err
+	}
 	return KeyToJSON(key, id)
 }

--- a/pygo-jwt/pygo_jwt/go/core/misc.go
+++ b/pygo-jwt/pygo_jwt/go/core/misc.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -21,4 +22,12 @@ func ExampleGo(n int) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func MaybeError(n int) (string, error) {
+	if n >= 0 {
+		return fmt.Sprintf("asdf %d", n), nil
+	} else {
+		return "", errors.New("positive only")
+	}
 }

--- a/pygo-jwt/pygo_jwt/go/core/sign_verify.go
+++ b/pygo-jwt/pygo_jwt/go/core/sign_verify.go
@@ -7,35 +7,51 @@ import (
 	"github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/util"
 )
 
-func Sign(key *rsa.PrivateKey, data string) string {
+func Sign(key *rsa.PrivateKey, data string) (string, error) {
 	result, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, util.SHA256Sum(data))
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return util.B64Enc(result)
+	return util.B64Enc(result), nil
 }
 
-func Verify(key *rsa.PublicKey, data string, signature string) bool {
-	err := rsa.VerifyPKCS1v15(key, crypto.SHA256, util.SHA256Sum(data), util.B64Dec(signature))
-	return err == nil
+func Verify(key *rsa.PublicKey, data string, signature string) (bool, error) {
+	signature_data, err := util.B64Dec(signature)
+	if err != nil {
+		return false, err
+	}
+	err = rsa.VerifyPKCS1v15(key, crypto.SHA256, util.SHA256Sum(data), signature_data)
+	return err == nil, nil
 }
 
-func ParseJWKAndSign(jwk string, data string) string {
-	key := ParseJWK(jwk)
+func ParseJWKAndSign(jwk string, data string) (string, error) {
+	key, err := ParseJWK(jwk)
+	if err != nil {
+		return "", err
+	}
 	return Sign(key, data)
 }
 
-func ParsePEMAndSign(pem string, data string) string {
-	key := ParsePEM(pem)
+func ParsePEMAndSign(pem string, data string) (string, error) {
+	key, err := ParsePEM(pem)
+	if err != nil {
+		return "", err
+	}
 	return Sign(key, data)
 }
 
-func ParsePublicJWKAndVerify(jwk string, data string, signature string) bool {
-	key := ParsePublicJWK(jwk)
+func ParsePublicJWKAndVerify(jwk string, data string, signature string) (bool, error) {
+	key, err := ParsePublicJWK(jwk)
+	if err != nil {
+		return false, err
+	}
 	return Verify(key, data, signature)
 }
 
-func ParsePublicPEMAndVerify(pem string, data string, signature string) bool {
-	key := ParsePublicPEM(pem)
+func ParsePublicPEMAndVerify(pem string, data string, signature string) (bool, error) {
+	key, err := ParsePublicPEM(pem)
+	if err != nil {
+		return false, err
+	}
 	return Verify(key, data, signature)
 }

--- a/pygo-jwt/pygo_jwt/go/core_test.go
+++ b/pygo-jwt/pygo_jwt/go/core_test.go
@@ -10,14 +10,14 @@ import "gotest.tools/assert"
 func TestFactory(t *testing.T) {
 	t.Run("general", func(t *testing.T) {
 		key_id := "asdf"
-		private_jwk := lib.NewJWK(16, &key_id)
-		private_pem := lib.JWKToPEM(private_jwk)
-		private_jwk2 := lib.PEMToJWK(private_pem, &key_id)
+		private_jwk, _ := lib.NewJWK(16, &key_id)
+		private_pem, _ := lib.JWKToPEM(private_jwk)
+		private_jwk2, _ := lib.PEMToJWK(private_pem, &key_id)
 		fmt.Println(private_jwk)
 		fmt.Println(private_pem)
 		assert.Equal(t, private_jwk, private_jwk2)
-		public_jwk := lib.ExtractPublicJWK(private_jwk)
-		public_pem := lib.ExtractPublicPEM(private_pem)
+		public_jwk, _ := lib.ExtractPublicJWK(private_jwk)
+		public_pem, _ := lib.ExtractPublicPEM(private_pem)
 		fmt.Println(public_jwk)
 		fmt.Println(public_pem)
 		assert.Equal(t, "hello world", "hello world")

--- a/pygo-jwt/pygo_jwt/go/util/b64_util.go
+++ b/pygo-jwt/pygo_jwt/go/util/b64_util.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"math/big"
 )
 
@@ -9,21 +11,33 @@ func B64Enc(data ByteSlice) string {
 	return base64.RawURLEncoding.EncodeToString(data)
 }
 
-func B64Dec(data string) ByteSlice {
-	res, err := base64.RawURLEncoding.DecodeString(data)
-	if err != nil {
-		panic(err)
-	}
-	return res
+func B64Dec(data string) (ByteSlice, error) {
+	return base64.RawURLEncoding.DecodeString(data)
 }
 
-func B64DecBigInt(data any) *big.Int {
+func B64DecBigInt(data any) (*big.Int, error) {
 	data_str, ok := data.(string)
 	if !ok {
-		panic("input data is not a string")
+		return nil, errors.New("input data is not a string")
 	}
-	buffer := B64Dec(data_str)
+	buffer, err := B64Dec(data_str)
+	if err != nil {
+		return nil, err
+	}
 	output := new(big.Int)
 	output.SetBytes(buffer)
-	return output
+	return output, nil
+}
+
+func B64DecBigIntMap(data StringMap, keys []string) (map[string]*big.Int, error) {
+	result := make(map[string]*big.Int)
+	for _, key := range keys {
+		val, err := B64DecBigInt(data[key])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode %s: %w", key, err)
+		} else {
+			result[key] = val
+		}
+	}
+	return result, nil
 }

--- a/pygo-jwt/pygo_jwt/go/util/hash_util.go
+++ b/pygo-jwt/pygo_jwt/go/util/hash_util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/sha256"
+	"errors"
 	"reflect"
 )
 
@@ -11,14 +12,14 @@ func ByteArrayToSlice32(array [32]byte) ByteSlice {
 	return slice
 }
 
-func ByteArrayToSlice(array any) ByteSlice {
+func ByteArrayToSlice(array any) (ByteSlice, error) {
 	_type := reflect.TypeOf(array)
 	if _type.Kind() != reflect.Array {
-		panic("unexpected data type")
+		return nil, errors.New("unexpected data type")
 	}
 	slice := make(ByteSlice, _type.Len())
 	reflect.Copy(reflect.ValueOf(slice), reflect.ValueOf(array))
-	return slice
+	return slice, nil
 }
 
 func SHA256Sum(data string) ByteSlice {

--- a/pygo-jwt/pygo_jwt/go/util/json_util.go
+++ b/pygo-jwt/pygo_jwt/go/util/json_util.go
@@ -2,32 +2,32 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
-func MapToJSON(data StringMap) string {
+func MapToJSON(data StringMap) (string, error) {
 	// TODO: move to ordered map?
 	result, err := json.Marshal(data)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return string(result)
+	return string(result), nil
 }
 
-func ParseJSON(json_data string) StringMap {
+func ParseJSON(json_data string) (StringMap, error) {
 	// TODO: move to ordered map?
 	var data StringMap
 	err := json.Unmarshal(StrEnc(json_data), &data)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return data
+	return data, nil
 }
 
 /* TODO
  * adopt bytes.Buffer; buffer.WriteString and buffer.Truncate methods
  * handle nested data
  */
+/*
 func MarshalOrdered(data StringMap) (ByteSlice, error) {
 	result := "{"
 	count := 0
@@ -48,6 +48,7 @@ func MarshalOrdered(data StringMap) (ByteSlice, error) {
 	result += "}"
 	return ByteSlice(result), nil
 }
+*/
 
 /*
  * NOTE: ordered map package

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -1,13 +1,18 @@
 package main
 
-import "C"
 import (
+	"errors"
+	"fmt"
 	lib "github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/core"
 	"unsafe"
 )
 
-// #include <stdlib.h>
-// #include <stdbool.h>
+/*
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct string_with_error {char* data; char* error;} StringWithError;
+*/
 import "C"
 
 //export NewJWK
@@ -72,6 +77,29 @@ func FreeCString(data *C.char) {
 //export ExampleGo
 func ExampleGo(n C.int) {
 	lib.ExampleGo(int(n))
+}
+
+func _MaybeError(n int) (string, error) {
+	if n >= 0 {
+		return fmt.Sprintf("asdf %d", n), nil
+	} else {
+		return "", errors.New("positive only")
+	}
+}
+
+func HandleStringWithError(res string, err error) C.StringWithError {
+	if err != nil {
+		return C.StringWithError{nil, C.CString(err.Error())}
+	} else {
+		return C.StringWithError{C.CString(res), nil}
+	}
+}
+
+//export MaybeError
+func MaybeError(n C.int) C.StringWithError {
+	m := int(n)
+	res, err := _MaybeError(m)
+	return HandleStringWithError(res, err)
 }
 
 func TranslateStrPtr(data *C.char) *string {

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -12,65 +12,76 @@ import (
 #include <stdbool.h>
 
 typedef struct string_with_error {char* data; char* error;} StringWithError;
+typedef struct bool_with_error {bool data; char* error;} BoolWithError;
 */
 import "C"
 
 //export NewJWK
-func NewJWK(size C.int, id *C.char) *C.char {
-	result := lib.NewJWK(int(size), TranslateStrPtr(id))
-	return C.CString(result)
+func NewJWK(size C.int, id *C.char) C.StringWithError {
+	res, err := lib.NewJWK(int(size), TranslateStrPtr(id))
+	return HandleStringWithError(res, err)
 }
 
 //export JWKToPEM
-func JWKToPEM(json_data *C.char) *C.char {
-	result := lib.JWKToPEM(C.GoString(json_data))
-	return C.CString(result)
+func JWKToPEM(json_data *C.char) C.StringWithError {
+	res, err := lib.JWKToPEM(C.GoString(json_data))
+	return HandleStringWithError(res, err)
 }
 
 //export PEMToJWK
-func PEMToJWK(pem *C.char, id *C.char) *C.char {
-	result := lib.PEMToJWK(C.GoString(pem), TranslateStrPtr(id))
-	return C.CString(result)
+func PEMToJWK(pem *C.char, id *C.char) C.StringWithError {
+	res, err := lib.PEMToJWK(C.GoString(pem), TranslateStrPtr(id))
+	return HandleStringWithError(res, err)
 }
 
 //export ParseJWKAndSign
-func ParseJWKAndSign(key *C.char, data *C.char) *C.char {
-	result := lib.ParseJWKAndSign(C.GoString(key), C.GoString(data))
-	return C.CString(result)
+func ParseJWKAndSign(key *C.char, data *C.char) C.StringWithError {
+	res, err := lib.ParseJWKAndSign(C.GoString(key), C.GoString(data))
+	return HandleStringWithError(res, err)
 }
 
 //export ParsePEMAndSign
-func ParsePEMAndSign(key *C.char, data *C.char) *C.char {
-	result := lib.ParsePEMAndSign(C.GoString(key), C.GoString(data))
-	return C.CString(result)
+func ParsePEMAndSign(key *C.char, data *C.char) C.StringWithError {
+	res, err := lib.ParsePEMAndSign(C.GoString(key), C.GoString(data))
+	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicJWK
-func ExtractPublicJWK(key *C.char) *C.char {
-	result := lib.ExtractPublicJWK(C.GoString(key))
-	return C.CString(result)
+func ExtractPublicJWK(key *C.char) C.StringWithError {
+	res, err := lib.ExtractPublicJWK(C.GoString(key))
+	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicPEM
-func ExtractPublicPEM(key *C.char) *C.char {
-	result := lib.ExtractPublicPEM(C.GoString(key))
-	return C.CString(result)
+func ExtractPublicPEM(key *C.char) C.StringWithError {
+	res, err := lib.ExtractPublicPEM(C.GoString(key))
+	return HandleStringWithError(res, err)
 }
 
 //export ParsePublicJWKAndVerify
-func ParsePublicJWKAndVerify(key *C.char, data *C.char, signature *C.char) C.bool {
-	result := lib.ParsePublicJWKAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
-	return C.bool(result)
+func ParsePublicJWKAndVerify(key *C.char, data *C.char, signature *C.char) C.BoolWithError {
+	res, err := lib.ParsePublicJWKAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
+	return HandleBoolWithError(res, err)
 }
 
 //export ParsePublicPEMAndVerify
-func ParsePublicPEMAndVerify(key *C.char, data *C.char, signature *C.char) C.bool {
-	result := lib.ParsePublicPEMAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
-	return C.bool(result)
+func ParsePublicPEMAndVerify(key *C.char, data *C.char, signature *C.char) C.BoolWithError {
+	res, err := lib.ParsePublicPEMAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
+	return HandleBoolWithError(res, err)
 }
 
 //export FreeCString
 func FreeCString(data *C.char) {
+	C.free(unsafe.Pointer(data))
+}
+
+//export FreeStringWithError
+func FreeStringWithError(data *C.StringWithError) {
+	C.free(unsafe.Pointer(data))
+}
+
+//export FreeBoolWithError
+func FreeBoolWithError(data *C.BoolWithError) {
 	C.free(unsafe.Pointer(data))
 }
 
@@ -92,6 +103,14 @@ func HandleStringWithError(res string, err error) C.StringWithError {
 		return C.StringWithError{nil, C.CString(err.Error())}
 	} else {
 		return C.StringWithError{C.CString(res), nil}
+	}
+}
+
+func HandleBoolWithError(res bool, err error) C.BoolWithError {
+	if err != nil {
+		return C.BoolWithError{false, C.CString(err.Error())}
+	} else {
+		return C.BoolWithError{C.bool(res), nil}
 	}
 }
 

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	lib "github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/core"
 )
 
@@ -68,18 +66,10 @@ func ExampleGo(n C.int) {
 	lib.ExampleGo(int(n))
 }
 
-func _MaybeError(n int) (string, error) {
-	if n >= 0 {
-		return fmt.Sprintf("asdf %d", n), nil
-	} else {
-		return "", errors.New("positive only")
-	}
-}
-
 //export MaybeError
 func MaybeError(n C.int) *C.StringWithError {
 	m := int(n)
-	res, err := _MaybeError(m)
+	res, err := lib.MaybeError(m)
 	return HandleStringWithError(res, err)
 }
 

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -4,85 +4,63 @@ import (
 	"errors"
 	"fmt"
 	lib "github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/core"
-	"unsafe"
 )
 
-/*
-#include <stdlib.h>
-#include <stdbool.h>
-
-typedef struct string_with_error {char* data; char* error;} StringWithError;
-typedef struct bool_with_error {bool data; char* error;} BoolWithError;
-*/
+// #include "wrapper_util.h"
 import "C"
 
 //export NewJWK
-func NewJWK(size C.int, id *C.char) C.StringWithError {
+func NewJWK(size C.int, id *C.char) *C.StringWithError {
 	res, err := lib.NewJWK(int(size), TranslateStrPtr(id))
 	return HandleStringWithError(res, err)
 }
 
 //export JWKToPEM
-func JWKToPEM(json_data *C.char) C.StringWithError {
+func JWKToPEM(json_data *C.char) *C.StringWithError {
 	res, err := lib.JWKToPEM(C.GoString(json_data))
 	return HandleStringWithError(res, err)
 }
 
 //export PEMToJWK
-func PEMToJWK(pem *C.char, id *C.char) C.StringWithError {
+func PEMToJWK(pem *C.char, id *C.char) *C.StringWithError {
 	res, err := lib.PEMToJWK(C.GoString(pem), TranslateStrPtr(id))
 	return HandleStringWithError(res, err)
 }
 
 //export ParseJWKAndSign
-func ParseJWKAndSign(key *C.char, data *C.char) C.StringWithError {
+func ParseJWKAndSign(key *C.char, data *C.char) *C.StringWithError {
 	res, err := lib.ParseJWKAndSign(C.GoString(key), C.GoString(data))
 	return HandleStringWithError(res, err)
 }
 
 //export ParsePEMAndSign
-func ParsePEMAndSign(key *C.char, data *C.char) C.StringWithError {
+func ParsePEMAndSign(key *C.char, data *C.char) *C.StringWithError {
 	res, err := lib.ParsePEMAndSign(C.GoString(key), C.GoString(data))
 	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicJWK
-func ExtractPublicJWK(key *C.char) C.StringWithError {
+func ExtractPublicJWK(key *C.char) *C.StringWithError {
 	res, err := lib.ExtractPublicJWK(C.GoString(key))
 	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicPEM
-func ExtractPublicPEM(key *C.char) C.StringWithError {
+func ExtractPublicPEM(key *C.char) *C.StringWithError {
 	res, err := lib.ExtractPublicPEM(C.GoString(key))
 	return HandleStringWithError(res, err)
 }
 
 //export ParsePublicJWKAndVerify
-func ParsePublicJWKAndVerify(key *C.char, data *C.char, signature *C.char) C.BoolWithError {
+func ParsePublicJWKAndVerify(key *C.char, data *C.char, signature *C.char) *C.BoolWithError {
 	res, err := lib.ParsePublicJWKAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
 	return HandleBoolWithError(res, err)
 }
 
 //export ParsePublicPEMAndVerify
-func ParsePublicPEMAndVerify(key *C.char, data *C.char, signature *C.char) C.BoolWithError {
+func ParsePublicPEMAndVerify(key *C.char, data *C.char, signature *C.char) *C.BoolWithError {
 	res, err := lib.ParsePublicPEMAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
 	return HandleBoolWithError(res, err)
-}
-
-//export FreeCString
-func FreeCString(data *C.char) {
-	C.free(unsafe.Pointer(data))
-}
-
-//export FreeStringWithError
-func FreeStringWithError(data *C.StringWithError) {
-	C.free(unsafe.Pointer(data))
-}
-
-//export FreeBoolWithError
-func FreeBoolWithError(data *C.BoolWithError) {
-	C.free(unsafe.Pointer(data))
 }
 
 //export ExampleGo
@@ -98,36 +76,11 @@ func _MaybeError(n int) (string, error) {
 	}
 }
 
-func HandleStringWithError(res string, err error) C.StringWithError {
-	if err != nil {
-		return C.StringWithError{nil, C.CString(err.Error())}
-	} else {
-		return C.StringWithError{C.CString(res), nil}
-	}
-}
-
-func HandleBoolWithError(res bool, err error) C.BoolWithError {
-	if err != nil {
-		return C.BoolWithError{false, C.CString(err.Error())}
-	} else {
-		return C.BoolWithError{C.bool(res), nil}
-	}
-}
-
 //export MaybeError
-func MaybeError(n C.int) C.StringWithError {
+func MaybeError(n C.int) *C.StringWithError {
 	m := int(n)
 	res, err := _MaybeError(m)
 	return HandleStringWithError(res, err)
-}
-
-func TranslateStrPtr(data *C.char) *string {
-	if data != nil {
-		result := C.GoString(data)
-		return &result
-	} else {
-		return nil
-	}
 }
 
 func main() {}

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -4,8 +4,21 @@ import (
 	lib "github.com/rkhullar/python-libraries/pygo-jwt/pygo_jwt/go/core"
 )
 
-// #include "wrapper_util.h"
+/*
+#ifndef WRAPPER_UTIL_H
+#define WRAPPER_UTIL_H
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct string_with_error {char* data; char* error;} StringWithError;
+typedef struct bool_with_error {bool data; char* error;} BoolWithError;
+
+#endif
+*/
 import "C"
+
+// TODO: change to `#include "wrapper_util.h"` once supported
 
 //export NewJWK
 func NewJWK(size C.int, id *C.char) *C.StringWithError {

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -34,8 +34,8 @@ func TranslateStrPtr(data *C.char) *string {
 	}
 }
 
-//export FreeCString
-func FreeCString(data *C.char) {
+//export FreeString
+func FreeString(data *C.char) {
 	_FreeStringMutex.Lock()
 	defer _FreeStringMutex.Unlock()
 	C.free(unsafe.Pointer(data))
@@ -46,10 +46,10 @@ func FreeStringWithError(object *C.StringWithError) {
 	_FreeStringErrorMutex.Lock()
 	defer _FreeStringErrorMutex.Unlock()
 	if object.data != nil {
-		FreeCString(object.data)
+		FreeString(object.data)
 	}
 	if object.error != nil {
-		FreeCString(object.error)
+		FreeString(object.error)
 	}
 	C.free(unsafe.Pointer(object))
 }
@@ -59,7 +59,7 @@ func FreeBoolWithError(object *C.BoolWithError) {
 	_FreeBoolErrorMutex.Lock()
 	defer _FreeBoolErrorMutex.Unlock()
 	if object.error != nil {
-		FreeCString(object.error)
+		FreeString(object.error)
 	}
 	C.free(unsafe.Pointer(object))
 }

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -64,20 +64,36 @@ func FreeBoolWithError(object *C.BoolWithError) {
 	C.free(unsafe.Pointer(object))
 }
 
+func NewStringWithError() *C.StringWithError {
+	return (*C.StringWithError)(C.malloc(C.size_t(unsafe.Sizeof(C.StringWithError{}))))
+}
+
+func NewBoolWithError() *C.BoolWithError {
+	return (*C.BoolWithError)(C.malloc(C.size_t(unsafe.Sizeof(C.BoolWithError{}))))
+}
+
 func HandleStringWithError(res string, err error) *C.StringWithError {
+	object := NewStringWithError()
 	if err != nil {
-		return &C.StringWithError{nil, C.CString(err.Error())}
+		object.data = nil
+		object.error = C.CString(err.Error())
 	} else {
-		return &C.StringWithError{C.CString(res), nil}
+		object.data = C.CString(res)
+		object.error = nil
 	}
+	return object
 }
 
 func HandleBoolWithError(res bool, err error) *C.BoolWithError {
+	object := NewBoolWithError()
 	if err != nil {
-		return &C.BoolWithError{false, C.CString(err.Error())}
+		object.data = false
+		object.error = C.CString(err.Error())
 	} else {
-		return &C.BoolWithError{C.bool(res), nil}
+		object.data = C.bool(res)
+		object.error = nil
 	}
+	return object
 }
 
 /*

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -1,0 +1,45 @@
+package main
+
+// #include "wrapper_util.h"
+import "C"
+import "unsafe"
+
+func TranslateStrPtr(data *C.char) *string {
+	if data != nil {
+		result := C.GoString(data)
+		return &result
+	} else {
+		return nil
+	}
+}
+
+//export FreeCString
+func FreeCString(data *C.char) {
+	C.free(unsafe.Pointer(data))
+}
+
+//export FreeStringWithError
+func FreeStringWithError(data *C.StringWithError) {
+	C.free(unsafe.Pointer(data))
+}
+
+//export FreeBoolWithError
+func FreeBoolWithError(data *C.BoolWithError) {
+	C.free(unsafe.Pointer(data))
+}
+
+func HandleStringWithError(res string, err error) *C.StringWithError {
+	if err != nil {
+		return &C.StringWithError{nil, C.CString(err.Error())}
+	} else {
+		return &C.StringWithError{C.CString(res), nil}
+	}
+}
+
+func HandleBoolWithError(res bool, err error) *C.BoolWithError {
+	if err != nil {
+		return &C.BoolWithError{false, C.CString(err.Error())}
+	} else {
+		return &C.BoolWithError{C.bool(res), nil}
+	}
+}

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -1,11 +1,25 @@
 package main
 
-// #include "wrapper_util.h"
-import "C"
 import (
 	"sync"
 	"unsafe"
 )
+
+/*
+#ifndef WRAPPER_UTIL_H
+#define WRAPPER_UTIL_H
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct string_with_error {char* data; char* error;} StringWithError;
+typedef struct bool_with_error {bool data; char* error;} BoolWithError;
+
+#endif
+*/
+import "C"
+
+// TODO: change to `#include "wrapper_util.h"` once supported
 
 var _FreeStringMutex sync.Mutex
 var _FreeStringErrorMutex sync.Mutex

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -84,4 +84,5 @@ func HandleBoolWithError(res bool, err error) *C.BoolWithError {
  * TODO
  * - check thread safety and mutex usage; implement mutex map?
  * - check memory leaks; use C.malloc?
+ * - how to prevent potential panic?
  */

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -99,6 +99,6 @@ func HandleBoolWithError(res bool, err error) *C.BoolWithError {
 /*
  * TODO
  * - check thread safety and mutex usage; implement mutex map?
- * - check memory leaks; use C.malloc?
+ * - check memory leaks; use reflection for C.malloc?; check double free?
  * - how to prevent potential panic?
  */

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -2,7 +2,14 @@ package main
 
 // #include "wrapper_util.h"
 import "C"
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
+
+var _FreeStringMutex sync.Mutex
+var _FreeStringErrorMutex sync.Mutex
+var _FreeBoolErrorMutex sync.Mutex
 
 func TranslateStrPtr(data *C.char) *string {
 	if data != nil {
@@ -15,17 +22,32 @@ func TranslateStrPtr(data *C.char) *string {
 
 //export FreeCString
 func FreeCString(data *C.char) {
+	_FreeStringMutex.Lock()
+	defer _FreeStringMutex.Unlock()
 	C.free(unsafe.Pointer(data))
 }
 
 //export FreeStringWithError
-func FreeStringWithError(data *C.StringWithError) {
-	C.free(unsafe.Pointer(data))
+func FreeStringWithError(object *C.StringWithError) {
+	_FreeStringErrorMutex.Lock()
+	defer _FreeStringErrorMutex.Unlock()
+	if object.data != nil {
+		FreeCString(object.data)
+	}
+	if object.error != nil {
+		FreeCString(object.error)
+	}
+	C.free(unsafe.Pointer(object))
 }
 
 //export FreeBoolWithError
-func FreeBoolWithError(data *C.BoolWithError) {
-	C.free(unsafe.Pointer(data))
+func FreeBoolWithError(object *C.BoolWithError) {
+	_FreeBoolErrorMutex.Lock()
+	defer _FreeBoolErrorMutex.Unlock()
+	if object.error != nil {
+		FreeCString(object.error)
+	}
+	C.free(unsafe.Pointer(object))
 }
 
 func HandleStringWithError(res string, err error) *C.StringWithError {
@@ -43,3 +65,9 @@ func HandleBoolWithError(res bool, err error) *C.BoolWithError {
 		return &C.BoolWithError{C.bool(res), nil}
 	}
 }
+
+/*
+ * TODO
+ * - check thread safety and mutex usage; implement mutex map?
+ * - check memory leaks; use C.malloc?
+ */

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.h
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.h
@@ -1,0 +1,10 @@
+#ifndef WRAPPER_UTIL_H
+#define WRAPPER_UTIL_H
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct string_with_error {char* data; char* error;} StringWithError;
+typedef struct bool_with_error {bool data; char* error;} BoolWithError;
+
+#endif

--- a/pygo-jwt/pygo_jwt/wrapper.py
+++ b/pygo-jwt/pygo_jwt/wrapper.py
@@ -93,6 +93,7 @@ class ExtensionAdapter:
     def maybe_error(cls, n: int):
         param = cls._encode_int(n)
         result = lib.MaybeError(param)
+        # TODO: create helper; deallocate struct
         if res := result.data:
             output = ffi.string(res).decode()
             return output

--- a/pygo-jwt/pygo_jwt/wrapper.py
+++ b/pygo-jwt/pygo_jwt/wrapper.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from _rsa_util import ffi, lib
-from .time_util import timed
-from .errors import CorePyGoJWTError
-from .wrapper_util import build_base_adapter
 
+from _rsa_util import ffi, lib
+
+from .errors import CorePyGoJWTError
+from .time_util import timed
+from .wrapper_util import build_base_adapter
 
 BaseExtensionAdapter = build_base_adapter(ffi, lib, error_type=CorePyGoJWTError)
 # TODO: move wrapper_util to pygo-tools

--- a/pygo-jwt/pygo_jwt/wrapper.py
+++ b/pygo-jwt/pygo_jwt/wrapper.py
@@ -1,27 +1,15 @@
 from dataclasses import dataclass
-
 from _rsa_util import ffi, lib
-
 from .time_util import timed
 from .errors import CorePyGoJWTError
+from .wrapper_util import build_base_adapter
+
+
+BaseExtensionAdapter = build_base_adapter(ffi, lib)
 
 
 @dataclass
-class ExtensionAdapter:
-
-    @staticmethod
-    def _encode_string(data: str):
-        return ffi.new('char[]', data.encode())
-
-    @staticmethod
-    def _encode_int(data: int):
-        return ffi.cast('int', data)
-
-    @staticmethod
-    def _decode_string(data) -> str:
-        output = ffi.string(data).decode()
-        lib.FreeCString(data)
-        return output
+class ExtensionAdapter(BaseExtensionAdapter):
 
     @classmethod
     def new_jwk(cls, size: int = 2048, _id: str = None) -> str:

--- a/pygo-jwt/pygo_jwt/wrapper.py
+++ b/pygo-jwt/pygo_jwt/wrapper.py
@@ -87,3 +87,8 @@ class ExtensionAdapter:
     def example_go(cls, n: int) -> None:
         param = cls._encode_int(n)
         lib.ExampleGo(param)
+
+    @classmethod
+    def maybe_error(cls, n: int):
+        param = cls._encode_int(n)
+        lib.MaybeError(param)

--- a/pygo-jwt/pygo_jwt/wrapper.py
+++ b/pygo-jwt/pygo_jwt/wrapper.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from _rsa_util import ffi, lib
 
 from .time_util import timed
+from .errors import CorePyGoJWTError
 
 
 @dataclass
@@ -91,4 +92,10 @@ class ExtensionAdapter:
     @classmethod
     def maybe_error(cls, n: int):
         param = cls._encode_int(n)
-        lib.MaybeError(param)
+        result = lib.MaybeError(param)
+        if res := result.data:
+            output = ffi.string(res).decode()
+            return output
+        elif err := result.error:
+            error_message = ffi.string(err).decode()
+            raise CorePyGoJWTError(error_message)

--- a/pygo-jwt/pygo_jwt/wrapper_util.py
+++ b/pygo-jwt/pygo_jwt/wrapper_util.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
-from typing import Callable
+from typing import Type
 
 
-def build_base_adapter(ffi, lib, free_string_name: str = 'FreeString'):
+def build_base_adapter(ffi, lib, error_type: Type[Exception], free_string_name: str = 'FreeString',
+                       free_string_with_error_name: str = 'FreeStringWithError',
+                       free_bool_with_error_name: str = 'FreeBoolWithError'):
+
+    free_string_func = getattr(lib, free_string_name)
+    free_string_with_error_func = getattr(lib, free_string_with_error_name)
+    free_bool_with_error_func = getattr(lib, free_bool_with_error_name)
 
     @dataclass
     class BaseExtensionAdapter:
@@ -18,11 +24,27 @@ def build_base_adapter(ffi, lib, free_string_name: str = 'FreeString'):
         @classmethod
         def _decode_string(cls, data) -> str:
             output = ffi.string(data).decode()
-            cls._free_string_func(data)
+            free_string_func(data)
             return output
 
-        @staticmethod
-        def _free_string_func() -> Callable:
-            return getattr(lib, free_string_name)
+        @classmethod
+        def _handle_string_with_error(cls, obj) -> str:
+            if res := obj.data:
+                free_string_with_error_func(obj)
+                return cls._decode_string(res)
+            elif err := obj.error:
+                free_string_with_error_func(obj)
+                error_message = cls._decode_string(err)
+                raise error_type(error_message)
+
+        @classmethod
+        def _handle_bool_with_error(cls, obj) -> bool:
+            if res := obj.data:
+                free_bool_with_error_func(obj)
+                return res
+            elif err := obj.error:
+                free_bool_with_error_func(obj)
+                error_message = cls._decode_string(err)
+                raise error_type(error_message)
 
     return BaseExtensionAdapter

--- a/pygo-jwt/pygo_jwt/wrapper_util.py
+++ b/pygo-jwt/pygo_jwt/wrapper_util.py
@@ -22,29 +22,32 @@ def build_base_adapter(ffi, lib, error_type: Type[Exception], free_string_name: 
             return ffi.cast('int', data)
 
         @classmethod
-        def _decode_string(cls, data) -> str:
+        def _decode_string(cls, data, free: bool = True) -> str:
             output = ffi.string(data).decode()
-            free_string_func(data)
+            if free:
+                free_string_func(data)
             return output
 
         @classmethod
         def _handle_string_with_error(cls, obj) -> str:
             if res := obj.data:
+                output = cls._decode_string(res, free=False)
                 free_string_with_error_func(obj)
-                return cls._decode_string(res)
+                return output
             elif err := obj.error:
+                error_message = cls._decode_string(err, free=False)
                 free_string_with_error_func(obj)
-                error_message = cls._decode_string(err)
                 raise error_type(error_message)
 
         @classmethod
         def _handle_bool_with_error(cls, obj) -> bool:
             if res := obj.data:
+                output = res
                 free_bool_with_error_func(obj)
-                return res
+                return output
             elif err := obj.error:
+                error_message = cls._decode_string(err, free=False)
                 free_bool_with_error_func(obj)
-                error_message = cls._decode_string(err)
                 raise error_type(error_message)
 
     return BaseExtensionAdapter

--- a/pygo-jwt/pygo_jwt/wrapper_util.py
+++ b/pygo-jwt/pygo_jwt/wrapper_util.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Callable
+
+
+def build_base_adapter(ffi, lib, free_string_name: str = 'FreeString'):
+
+    @dataclass
+    class BaseExtensionAdapter:
+
+        @staticmethod
+        def _encode_string(data: str):
+            return ffi.new('char[]', data.encode())
+
+        @staticmethod
+        def _encode_int(data: int):
+            return ffi.cast('int', data)
+
+        @classmethod
+        def _decode_string(cls, data) -> str:
+            output = ffi.string(data).decode()
+            cls._free_string_func(data)
+            return output
+
+        @staticmethod
+        def _free_string_func() -> Callable:
+            return getattr(lib, free_string_name)
+
+    return BaseExtensionAdapter

--- a/pygo-jwt/readme.md
+++ b/pygo-jwt/readme.md
@@ -40,7 +40,9 @@ import (
 )
 
 func main() {
-	key := lib.NewJWK(2048, nil)
-	fmt.Println(key)
+	private_jwk, _ := lib.NewJWK(2048, nil)
+	private_pem, _ := lib.JWKToPEM(private_jwk)
+	fmt.Println(private_jwk)
+	fmt.Println(private_pem)
 }
 ```

--- a/pygo-jwt/setup.py
+++ b/pygo-jwt/setup.py
@@ -10,13 +10,14 @@ def read_file(path: Path | str) -> str:
 
 setup(
     name='pygo-jwt',
-    version='0.0.3',
+    version='0.0.4',
     packages=find_packages(),
     include_package_data=True,
     python_requires='~=3.12',
     author='Rajan Khullar',
     author_email='rkhullar03@gmail.com',
     license='MIT NON-AI',
+    description="encode and decode RS256 JSON Web Tokens with python and go",
     long_description=read_file('readme.md'),
     long_description_content_type='text/markdown',
     project_urls={

--- a/pygo-jwt/setup.py
+++ b/pygo-jwt/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Rajan Khullar',
     author_email='rkhullar03@gmail.com',
     license='MIT NON-AI',
-    description="encode and decode RS256 JSON Web Tokens with python and go",
+    description="Encode and Decode RS256 JSON Web Tokens with Python and Go",
     long_description=read_file('readme.md'),
     long_description_content_type='text/markdown',
     project_urls={


### PR DESCRIPTION
## Description
This PR primarily updates the pygo-jwt core logic to return errors instead of panicking. The previous approach allowed for a simpler interface between Go and Python since no structs were involved. However, the panic would cause the calling Python program to crash, and it would not be recoverable via try-catch. This issue is resolved in this PR, but the memory management between Go and Python is complex and should be further tested.