### PR TITLE
extend pygo-jwt error handling to prevent panics

### DIFF
--- a/pygo-jwt/pygo_jwt/go/core/misc.go
+++ b/pygo-jwt/pygo_jwt/go/core/misc.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -26,7 +25,7 @@ func ExampleGo(n int) {
 
 func MaybeError(n int) (string, error) {
 	if n < 0 {
-		return "", errors.New("positive only")
+		return "", fmt.Errorf("positive only: %d", n)
 	} else if n > 100 {
 		panic("intentional panic")
 	} else {

--- a/pygo-jwt/pygo_jwt/go/core/misc.go
+++ b/pygo-jwt/pygo_jwt/go/core/misc.go
@@ -25,9 +25,11 @@ func ExampleGo(n int) {
 }
 
 func MaybeError(n int) (string, error) {
-	if n >= 0 {
-		return fmt.Sprintf("asdf %d", n), nil
-	} else {
+	if n < 0 {
 		return "", errors.New("positive only")
+	} else if n > 100 {
+		panic("intentional panic")
+	} else {
+		return fmt.Sprintf("asdf %d", n), nil
 	}
 }

--- a/pygo-jwt/pygo_jwt/go/wrapper.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper.go
@@ -22,65 +22,76 @@ import "C"
 
 //export NewJWK
 func NewJWK(size C.int, id *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.NewJWK(int(size), TranslateStrPtr(id))
 	return HandleStringWithError(res, err)
 }
 
 //export JWKToPEM
 func JWKToPEM(json_data *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.JWKToPEM(C.GoString(json_data))
 	return HandleStringWithError(res, err)
 }
 
 //export PEMToJWK
 func PEMToJWK(pem *C.char, id *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.PEMToJWK(C.GoString(pem), TranslateStrPtr(id))
 	return HandleStringWithError(res, err)
 }
 
 //export ParseJWKAndSign
 func ParseJWKAndSign(key *C.char, data *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.ParseJWKAndSign(C.GoString(key), C.GoString(data))
 	return HandleStringWithError(res, err)
 }
 
 //export ParsePEMAndSign
 func ParsePEMAndSign(key *C.char, data *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.ParsePEMAndSign(C.GoString(key), C.GoString(data))
 	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicJWK
 func ExtractPublicJWK(key *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.ExtractPublicJWK(C.GoString(key))
 	return HandleStringWithError(res, err)
 }
 
 //export ExtractPublicPEM
 func ExtractPublicPEM(key *C.char) *C.StringWithError {
+	defer PreventPanic()
 	res, err := lib.ExtractPublicPEM(C.GoString(key))
 	return HandleStringWithError(res, err)
 }
 
 //export ParsePublicJWKAndVerify
 func ParsePublicJWKAndVerify(key *C.char, data *C.char, signature *C.char) *C.BoolWithError {
+	defer PreventPanic()
 	res, err := lib.ParsePublicJWKAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
 	return HandleBoolWithError(res, err)
 }
 
 //export ParsePublicPEMAndVerify
 func ParsePublicPEMAndVerify(key *C.char, data *C.char, signature *C.char) *C.BoolWithError {
+	defer PreventPanic()
 	res, err := lib.ParsePublicPEMAndVerify(C.GoString(key), C.GoString(data), C.GoString(signature))
 	return HandleBoolWithError(res, err)
 }
 
 //export ExampleGo
 func ExampleGo(n C.int) {
+	defer PreventPanic()
 	lib.ExampleGo(int(n))
 }
 
 //export MaybeError
 func MaybeError(n C.int) *C.StringWithError {
+	defer PreventPanic()
 	m := int(n)
 	res, err := lib.MaybeError(m)
 	return HandleStringWithError(res, err)

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"sync"
 	"unsafe"
 )
@@ -36,6 +37,7 @@ func TranslateStrPtr(data *C.char) *string {
 
 //export FreeString
 func FreeString(data *C.char) {
+	defer PreventPanic()
 	_FreeStringMutex.Lock()
 	defer _FreeStringMutex.Unlock()
 	C.free(unsafe.Pointer(data))
@@ -43,6 +45,7 @@ func FreeString(data *C.char) {
 
 //export FreeStringWithError
 func FreeStringWithError(object *C.StringWithError) {
+	defer PreventPanic()
 	_FreeStringErrorMutex.Lock()
 	defer _FreeStringErrorMutex.Unlock()
 	if object.data != nil {
@@ -56,6 +59,7 @@ func FreeStringWithError(object *C.StringWithError) {
 
 //export FreeBoolWithError
 func FreeBoolWithError(object *C.BoolWithError) {
+	defer PreventPanic()
 	_FreeBoolErrorMutex.Lock()
 	defer _FreeBoolErrorMutex.Unlock()
 	if object.error != nil {
@@ -96,9 +100,14 @@ func HandleBoolWithError(res bool, err error) *C.BoolWithError {
 	return object
 }
 
+func PreventPanic() {
+	if r := recover(); r != nil {
+		fmt.Println("recover from panic", r)
+	}
+}
+
 /*
  * TODO
  * - check thread safety and mutex usage; implement mutex map?
  * - check memory leaks; use reflection for C.malloc?; check double free?
- * - how to prevent potential panic?
  */

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -110,4 +110,5 @@ func PreventPanic() {
  * TODO
  * - check thread safety and mutex usage; implement mutex map?
  * - check memory leaks; use reflection for C.malloc?; check double free?
+ * - how to prevent memory errors? i.e: pointer being freed was not allocated
  */

--- a/pygo-jwt/pygo_jwt/go/wrapper_util.go
+++ b/pygo-jwt/pygo_jwt/go/wrapper_util.go
@@ -102,7 +102,7 @@ func HandleBoolWithError(res bool, err error) *C.BoolWithError {
 
 func PreventPanic() {
 	if r := recover(); r != nil {
-		fmt.Println("recover from panic", r)
+		fmt.Println("recovered from panic: ", r)
 	}
 }
 

--- a/pygo-jwt/pygo_jwt/wrapper_util.py
+++ b/pygo-jwt/pygo_jwt/wrapper_util.py
@@ -30,7 +30,9 @@ def build_base_adapter(ffi, lib, error_type: Type[Exception], free_string_name: 
 
         @classmethod
         def _handle_string_with_error(cls, obj) -> str:
-            if res := obj.data:
+            if obj == ffi.NULL:
+                raise error_type
+            elif res := obj.data:
                 output = cls._decode_string(res, free=False)
                 free_string_with_error_func(obj)
                 return output
@@ -41,7 +43,9 @@ def build_base_adapter(ffi, lib, error_type: Type[Exception], free_string_name: 
 
         @classmethod
         def _handle_bool_with_error(cls, obj) -> bool:
-            if res := obj.data:
+            if obj == ffi.NULL:
+                raise error_type
+            elif res := obj.data:
                 output = res
                 free_bool_with_error_func(obj)
                 return output

--- a/pygo-jwt/setup.py
+++ b/pygo-jwt/setup.py
@@ -10,7 +10,7 @@ def read_file(path: Path | str) -> str:
 
 setup(
     name='pygo-jwt',
-    version='0.0.4',
+    version='0.0.5',
     packages=find_packages(),
     include_package_data=True,
     python_requires='~=3.12',

--- a/pygo-jwt/tests/test-handle-panic.py
+++ b/pygo-jwt/tests/test-handle-panic.py
@@ -1,0 +1,16 @@
+import pygo_jwt
+
+adapter = pygo_jwt.ExtensionAdapter()
+
+for i in range(4):
+    try:
+        print(adapter.maybe_error(i))
+        print(adapter.maybe_error(-i))
+    except pygo_jwt.errors.CorePyGoJWTError as err:
+        print('caught pygo error:', err)
+
+for i in range(94, 106):
+    try:
+        print(adapter.maybe_error(i))
+    except pygo_jwt.errors.CorePyGoJWTError as err:
+        print(f'caught pygo error on {i=}:', err)


### PR DESCRIPTION
## Related Links
- https://github.com/rkhullar/python-libraries/pull/19

## Description
This PR expands on the previous error handling by attempting to prevent potential panics on the Go side. In order to test this flow ,the `MaybeError` function has been updated to intentionally panic on certain input. All exported cgo functions are modified with a deferred call to `PreventPanic`. On the python side the wrapper util functions are updated to check for null pointers.

### Caveats
- There are still other potential errors that can cause the calling python program to crash. If the call to `_decode_string` within`_handle_bool_with_error` is changed to `free=False`, then instead of gracefully handling an error, the program crashes with the following: `pointer being freed was not allocated`