### PR TITLE
publish sdist for pygo-jwt

### DIFF
--- a/.github/workflows/build-pygo-jwt.yaml
+++ b/.github/workflows/build-pygo-jwt.yaml
@@ -5,12 +5,41 @@ on:
   push:
     branches:
       - release/pygo-jwt
+      - feature/pygo-jwt
 
 env:
   package: "pygo-jwt"
   go_version: 1.21.8
 
 jobs:
+  build_sdist:
+    name: build sdist
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pygo-jwt
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: install requirements
+        run: |
+          pip install pipenv
+          pipenv lock
+          pipenv requirements --dev > requirements.txt
+          pip install -r requirements.txt
+
+      - name: build sdist
+        run: python -m build -n --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-sdist-${{ env.package }}-${{ strategy.job-index }}
+          path: ${{ env.package }}/dist/*
+
   build_wheels:
     name: build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -48,7 +77,7 @@ jobs:
 
   publish_test:
     if: github.event_name == 'workflow_dispatch'
-    needs: [build_wheels]
+    needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -59,6 +88,7 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-pygo-jwt.yaml
+++ b/.github/workflows/build-pygo-jwt.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - release/pygo-jwt
-      - feature/pygo-jwt
 
 env:
   package: "pygo-jwt"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,12 +19,11 @@ twine upload dist/*
 pip install 'pygo-tools @ git+https://github.com/rkhullar/python-libraries.git@feature/toml#subdirectory=pygo-tools'
 ```
 
-## Install from Source Distribution (wip)
+## Install from Source Distribution
 ```shell
-pip install cython
-pip install meson-python
-pip install numpy --no-binary ':all:'
-# did not wok
+pip install -U pip setuptools
+pip install pygo-tools
+pip install pygo-jwt --no-cache-dir --no-binary ':all:'
 ```
 
 ## Useful Links

--- a/pygo-jwt/setup.py
+++ b/pygo-jwt/setup.py
@@ -11,7 +11,7 @@ def read_file(path: Path | str) -> str:
 
 setup(
     name='pygo-jwt',
-    version='0.0.8.dev1',
+    version='0.0.8',
     packages=find_packages(),
     include_package_data=True,
     python_requires='>=3.10, <4.0',


### PR DESCRIPTION
## Related Links
- https://github.com/rkhullar/python-libraries/pull/24

## Description
This PR follow up on the previous PR by including the source distribution build for pygo-jwt in github actions and publishing to testpyi.