### PR TITLE
bugfix for pygo-tools

### DIFF
--- a/pygo-tools/pygo_tools/__init__.py
+++ b/pygo-tools/pygo_tools/__init__.py
@@ -1,4 +1,4 @@
 from .config import Config
 from .setup import patch_wheel_darwin, setup
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/pygo-tools/pygo_tools/backend.py
+++ b/pygo-tools/pygo_tools/backend.py
@@ -1,12 +1,13 @@
 import tempfile
+from pathlib import Path
 
 from setuptools import build_meta as _build_meta
 from setuptools.build_meta import *
 from wheel.bdist_wheel import bdist_wheel
-from pathlib import Path
 
 from .config import Config
-from .setup import build_ffi, inject_file, patch_wheel_darwin, precompile,find_wheel
+from .setup import (build_ffi, find_wheel, inject_file, patch_wheel_darwin,
+                    precompile)
 from .util import monkey_patched
 
 
@@ -19,12 +20,6 @@ class custom_bdist_wheel(bdist_wheel):
             if dep not in install_requires:
                 install_requires.append(dep)
 
-    def run(self):
-        print('hook before base run')
-        result = super(self).run()
-        print('hook after base run')
-        return result
-
 
 @monkey_patched(original=bdist_wheel, extended=custom_bdist_wheel, to_patch=['finalize_options'])
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
@@ -35,11 +30,6 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         result = _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
         inject_file(config, path=source_ffi_path)
         if config.platform == 'darwin':
-            print('='*100)
-            print(wheel_directory)
-            print(type(wheel_directory))
-            print()
-            print('='*100)
             wheel_path = find_wheel(config, dist_path=Path(wheel_directory))
             if not wheel_path:
                 raise FileNotFoundError(f'could not find wheel to patch')

--- a/pygo-tools/pygo_tools/backend.py
+++ b/pygo-tools/pygo_tools/backend.py
@@ -3,9 +3,10 @@ import tempfile
 from setuptools import build_meta as _build_meta
 from setuptools.build_meta import *
 from wheel.bdist_wheel import bdist_wheel
+from pathlib import Path
 
 from .config import Config
-from .setup import build_ffi, inject_file, patch_wheel_darwin, precompile
+from .setup import build_ffi, inject_file, patch_wheel_darwin, precompile,find_wheel
 from .util import monkey_patched
 
 
@@ -18,6 +19,12 @@ class custom_bdist_wheel(bdist_wheel):
             if dep not in install_requires:
                 install_requires.append(dep)
 
+    def run(self):
+        print('hook before base run')
+        result = super(self).run()
+        print('hook after base run')
+        return result
+
 
 @monkey_patched(original=bdist_wheel, extended=custom_bdist_wheel, to_patch=['finalize_options'])
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
@@ -28,5 +35,13 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         result = _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
         inject_file(config, path=source_ffi_path)
         if config.platform == 'darwin':
-            patch_wheel_darwin(config)
+            print('='*100)
+            print(wheel_directory)
+            print(type(wheel_directory))
+            print()
+            print('='*100)
+            wheel_path = find_wheel(config, dist_path=Path(wheel_directory))
+            if not wheel_path:
+                raise FileNotFoundError(f'could not find wheel to patch')
+            patch_wheel_darwin(config, wheel_path=wheel_path)
     return result


### PR DESCRIPTION
## Related Links
- https://github.com/rkhullar/python-libraries/pull/24
- https://github.com/rkhullar/python-libraries/pull/26

## Description
The previous PR for `pygo-tools` updated the function signature for `patch_wheel_darwin` and updated the caller for the `setup.py` build option. This PR includes the missing caller update for the `pyproject.toml` option.